### PR TITLE
Disable scheduled workflow run

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,6 @@ name: Docker
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '43 08 * * 0'
   push:
     branches: [ "main" ]
     # Publish semver tags as releases.


### PR DESCRIPTION
Reason is that GitHub disables workflows if there is no activity in the repo for some time. Thus the workflow doesn't run anymore, even on a push or a pull request event.